### PR TITLE
chore: Add --diff-filter option for filtering diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint src --ext .ts,.tsx",
-    "lint-diff": "eslint $(git diff --name-only origin/$BASE origin/$HEAD | grep -E '\\.((j|t)sx?)$' | xargs)"
+    "lint-diff": "eslint $(git diff --name-only --diff-filter=duxb origin/$BASE origin/$HEAD | grep -E '\\.((j|t)sx?)$' | xargs)"
   },
   "dependencies": {
     "react": "^18.0.0",


### PR DESCRIPTION
## What does this PR do?

<!-- Fill the description of this PR below -->
Prevent `lint-diff` script from checking deleted files

Check [[Bug] ESLint on PR fails when files are deleted #5](https://github.com/bbodeuk/bookdart-server/issues/5)

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Code improvements
- [ ] Breaking change
- [ ] Documentation
- [ ] etc.

## Changes

- Add `--diff-filter=duxb` to `lint-diff` script
  - d: deleted
  - u: unmerged
  - x: unknown
  - b: broken
